### PR TITLE
Allow short-circuiting

### DIFF
--- a/jquery.scrollbar.js
+++ b/jquery.scrollbar.js
@@ -19,25 +19,25 @@
     var debug = false;
     var lmb = 1, px = "px";
 
-	// do scrollbars displace content
-	function hasOverlayScrollBars() {
-		// Create the measurement node
-		var scrollDiv = $("<div></div>").css({
-			width: "100px",
-			height: "100px",
-			overflow: "scroll",
-			position: "absolute",
-			top: "-9999px"
-		})[0];
-
-		// Get the scroll bar width
-		document.body.appendChild(scrollDiv);
-		var scrollBarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
-
-		// Delete the measurement div
-		document.body.removeChild(scrollDiv);
-		return !scrollBarWidth;
-	}
+    // do scrollbars displace content
+    function hasOverlayScrollBars() {
+        // Create the measurement node
+        var scrollDiv = $("<div></div>").css({
+            width: "100px",
+            height: "100px",
+            overflow: "scroll",
+            position: "absolute",
+            top: "-9999px"
+        })[0];
+        
+        // Get the scroll bar width
+        document.body.appendChild(scrollDiv);
+        var scrollBarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
+        
+        // Delete the measurement div
+        document.body.removeChild(scrollDiv);
+        return !scrollBarWidth;
+    }
 
     var browser = {
         "data": {},
@@ -66,30 +66,6 @@
         }
     };
     
-     // do scrollbars displace content
-    function hasOverlayScrollBars() {
-    	// Create the measurement node
-    	var scrollDiv = $("<div></div>").css({
-    		width: "100px",
-    		height: "100px",
-    		overflow: "scroll",
-    		position: "absolute",
-    		top: "-9999px"
-    	})[0];
-    
-    	// Get the scroll bar width
-    	document.body.appendChild(scrollDiv);
-    	var scrollBarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
-    
-    	// Delete the measurement div
-    	document.body.removeChild(scrollDiv);
-    	scrollBarsMeasured = true;
-    	scrollBarsOverlay = !scrollBarWidth;
-    	return scrollBarsOverlay;
-    }
-
-    var scrollbarsOverlay = hasOverlayScrollBars();
-
     var defaults = {
         "autoScrollSize": true,     // automatically calculate scrollsize
         "autoUpdate": true,         // update scrollbar if content/container size changed


### PR DESCRIPTION
Added support via the new option allowOverlayBars to disable the plugin when OS bars overlay the content. This corresponds with how most modern browsers handle scrollbars, it is often the effect you are going for when you use this plugin and if its already acceptable why run this code. Now you don't have to.
