### PR TITLE
Updated main to point to the new index.js for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jquery.scrollbar",
   "version": "0.2.7",
   "description": "Cross-browser CSS customizable scrollbar",
-  "main": "jquery.scrollbar.min.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Sorry about the second PR, but in order to take advantage of the module.exports the main in package.json needs to point to index.js