### PR TITLE
Fix minification of angular directive

### DIFF
--- a/jquery.scrollbar.js
+++ b/jquery.scrollbar.js
@@ -763,7 +763,7 @@
                         }
                     };
                 })
-                .directive('jqueryScrollbar', function (jQueryScrollbar, $parse) {
+                .directive('jqueryScrollbar', ['jQueryScrollbar', '$parse', function (jQueryScrollbar, $parse) {
                     return {
                         "restrict": "AC",
                         "link": function (scope, element, attrs) {
@@ -775,7 +775,7 @@
                                 });
                         }
                     };
-                });
+                }]);
         })(window.angular);
     }
 }));


### PR DESCRIPTION
Explicitly set injectables in `jqueryScrollbar` directive so that it survives after variable mangling minification (uglify etc.).