### PR TITLE
When using disableBodyScroll, set stored scrollTo value to the initia…

### DIFF
--- a/jquery.scrollbar.js
+++ b/jquery.scrollbar.js
@@ -277,10 +277,6 @@
                         scrollx.scroll.addClass('scroll-element_arrows_visible');
                     }
 
-                    scrollx._setScrollToValue = function(val) {
-                        scrollToValue = val;
-                    };
-
                     scrollx.mousewheel = function (event) {
 
                         if (!scrollx.isVisible || (d === 'x' && isVerticalScroll(event))) {
@@ -403,7 +399,7 @@
                         }, event);
                     });
                 }
-                scrollx._setScrollToValue(initScroll[scrollOffset]);
+                setTimeout(scrollx.scroll.trigger.bind(scrollx.scroll, 'mouseenter'), 0);
             });
 
             // remove classes & reset applied styles

--- a/jquery.scrollbar.js
+++ b/jquery.scrollbar.js
@@ -277,6 +277,10 @@
                         scrollx.scroll.addClass('scroll-element_arrows_visible');
                     }
 
+                    scrollx._setScrollToValue = function(val) {
+                        scrollToValue = val;
+                    };
+
                     scrollx.mousewheel = function (event) {
 
                         if (!scrollx.isVisible || (d === 'x' && isVerticalScroll(event))) {
@@ -399,6 +403,7 @@
                         }, event);
                     });
                 }
+                scrollx._setScrollToValue(initScroll[scrollOffset]);
             });
 
             // remove classes & reset applied styles

--- a/jquery.scrollbar.js
+++ b/jquery.scrollbar.js
@@ -213,7 +213,11 @@
                     };
                     w.on('MozMousePixelScroll' + namespace, handleMouseScroll);
                     w.on('mousewheel' + namespace, handleMouseScroll);
-
+                    c.on('mouseenter' + namespace, function(){
+                        s.x.scroll.trigger('mouseenter');
+                        s.y.scroll.trigger('mouseenter');
+                    });
+					
                     if (browser.mobile) {
                         w.on('touchstart' + namespace, function (event) {
                             var touch = event.originalEvent.touches && event.originalEvent.touches[0] || event;


### PR DESCRIPTION
…l scrolled position, as well as upon subsequent calls to init.

Hi Gromo, didn't find any information on the best way to submit proposed changes. If you'd prefer that i open up an issue or something else instead let me know.

I have the use case where i programatically scroll to a position initially. however when i mousewheel with disableBodyScroll: true, the mousewheel, assumes that initial scroll is 0, instead of the actual value and scrolls there.

thxs!