### PR TITLE
Enable jquery.scrollbar for Firefox

### DIFF
--- a/jquery.scrollbar.js
+++ b/jquery.scrollbar.js
@@ -162,7 +162,6 @@
             // do not init if in ignorable browser
             if ((browser.mobile && o.ignoreMobile)
                 || (browser.overlay && o.ignoreOverlay)
-                || (browser.macosx && !browser.webkit) // still required to ignore nonWebKit browsers on Mac
                 ) {
                 if ($.isFunction(o.onFallback)) {
                     o.onFallback.apply(this, [c]);


### PR DESCRIPTION
From what I can tell from @gromo's comment [here](https://github.com/gromo/jquery.scrollbar/issues/83#issuecomment-186193995) the reason for disabling Firefox usage was due to not being able to hide the native scrollbar. 

I have removed the line that prevented jquery.scrollbar's usage in Firefox and it seems to be working as expected for me.